### PR TITLE
Don't overwrite file if SQL is invalid

### DIFF
--- a/format_sql/main.py
+++ b/format_sql/main.py
@@ -130,11 +130,7 @@ def handle_sql_file(filename, debug=False):
     with open(filename) as f:
         lines = f.read()
 
-    try:
-        sql = format_sql(lines, debug)
-    except InvalidSQL as e:
-        print_non_data(e)
-        return
+    sql = format_sql(lines, debug)
 
     lines = '\n'.join(sql)
     return lines


### PR DESCRIPTION
Prior to this change, if the input file contained invalid SQL it would
be overwritten with an empty file. This change lets the exception
propagate so that the file is left untouched.

> ➜  format-sql git:(no-overwrite-invalid) cat /tmp/invalid.sql
> SELECT foo, bar FROMM snoober;
> ➜  format-sql git:(no-overwrite-invalid) python format_sql/main.py /tmp/invalid.sql
> /tmp/invalid.sql
> Traceback (most recent call last):
>   File "format_sql/main.py", line 148, in <module>
>     main()
>   File "format_sql/main.py", line 81, in main
>     lines = handle_sql_file(filename, args.debug)
>   File "format_sql/main.py", line 133, in handle_sql_file
>     sql = format_sql(lines, debug)
>   File "/Users/andrewstahlman/src/oss/format-sql/format_sql/shortcuts.py", line 20, in format_sql
>     parsed = list(parse(tokens))
>   File "/Users/andrewstahlman/src/oss/format-sql/format_sql/parser.py", line 762, in parse
>     for statement, unused_count in _parse(toks):
>   File "/Users/andrewstahlman/src/oss/format-sql/format_sql/parser.py", line 755, in _parse
>     raise InvalidSQL()
> format_sql.parser.InvalidSQL
> ➜  format-sql git:(no-overwrite-invalid) git checkout master
> Switched to branch 'master'
> Your branch is up-to-date with 'origin/master'.
> ➜  format-sql git:(master) python format_sql/main.py /tmp/invalid.sql
> /tmp/invalid.sql
> 
> Traceback (most recent call last):
>   File "format_sql/main.py", line 152, in <module>
>     main()
>   File "format_sql/main.py", line 83, in main
>     _write_back(filename, lines, args.dry_run)
>   File "format_sql/main.py", line 148, in _write_back
>     f.write(lines)
> TypeError: expected a string or other character buffer object
> ➜  format-sql git:(master) cat /tmp/invalid.sql
> ➜  format-sql git:(master)
